### PR TITLE
Add support for -u argument to run WSL commands as something besides root

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The import of these functions replaces any PowerShell aliases that conflict with
     * Note: An example command is `Import-WslCommand "apt", "awk", "emacs", "grep", "head", "less", "ls", "man", "sed", "seq", "ssh", "sudo", "tail", "vim"`. Add this to your [profile](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles) for persistent access.
 * (Optionally) Define a [hash table](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_hash_tables?view=powershell-6#creating-hash-tables) called `$WslDefaultParameterValues` and set default arguments for commands using the pattern `$WslDefaultParameterValues["<COMMAND>"] = "<ARGS>"`
     * Note: You can change the distribution `wsl` uses by setting `$WslDefaultParameterValues["-d"] = "<DISTRIBUTION>"`. This will set `wsl -d` when calling into `wsl`.
-    * Note: You can change the username `wsl` uses by setting `$WslDefaultParameterValues["-u"] = "username"`. This will set `wsl -u` when calling into `wsl` and allow you to run as something else than root.
+    * Note: You can change the username `wsl` uses by setting `$WslDefaultParameterValues["-u"] = "<username>"`. This will set `wsl -u` when calling into `wsl` and allow you to run as something else than root.
 * (Optionally) Define a [hash table](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_hash_tables?view=powershell-6#creating-hash-tables) called `$WslEnvironmentVariables` and set environment variables using the pattern `$WslEnvironmentVariables["<NAME>"] = "<VALUE>"` or use [WSLENV](https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/)
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The import of these functions replaces any PowerShell aliases that conflict with
     * Note: An example command is `Import-WslCommand "apt", "awk", "emacs", "grep", "head", "less", "ls", "man", "sed", "seq", "ssh", "sudo", "tail", "vim"`. Add this to your [profile](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles) for persistent access.
 * (Optionally) Define a [hash table](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_hash_tables?view=powershell-6#creating-hash-tables) called `$WslDefaultParameterValues` and set default arguments for commands using the pattern `$WslDefaultParameterValues["<COMMAND>"] = "<ARGS>"`
     * Note: You can change the distribution `wsl` uses by setting `$WslDefaultParameterValues["-d"] = "<DISTRIBUTION>"`. This will set `wsl -d` when calling into `wsl`.
+    * Note: You can change the username `wsl` uses by setting `$WslDefaultParameterValues["-u"] = "username"`. This will set `wsl -u` when calling into `wsl` and allow you to run as something else than root.
 * (Optionally) Define a [hash table](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_hash_tables?view=powershell-6#creating-hash-tables) called `$WslEnvironmentVariables` and set environment variables using the pattern `$WslEnvironmentVariables["<NAME>"] = "<VALUE>"` or use [WSLENV](https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/)
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The import of these functions replaces any PowerShell aliases that conflict with
     * Note: An example command is `Import-WslCommand "apt", "awk", "emacs", "grep", "head", "less", "ls", "man", "sed", "seq", "ssh", "sudo", "tail", "vim"`. Add this to your [profile](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles) for persistent access.
 * (Optionally) Define a [hash table](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_hash_tables?view=powershell-6#creating-hash-tables) called `$WslDefaultParameterValues` and set default arguments for commands using the pattern `$WslDefaultParameterValues["<COMMAND>"] = "<ARGS>"`
     * Note: You can change the distribution `wsl` uses by setting `$WslDefaultParameterValues["-d"] = "<DISTRIBUTION>"`. This will set `wsl -d` when calling into `wsl`.
-    * Note: You can change the username `wsl` uses by setting `$WslDefaultParameterValues["-u"] = "<username>"`. This will set `wsl -u` when calling into `wsl` and allow you to run as something else than root.
+    * Note: You can change the username `wsl` uses by setting `$WslDefaultParameterValues["-u"] = "<USERNAME>"`. This will set `wsl -u` when calling into `wsl`.
 * (Optionally) Define a [hash table](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_hash_tables?view=powershell-6#creating-hash-tables) called `$WslEnvironmentVariables` and set environment variables using the pattern `$WslEnvironmentVariables["<NAME>"] = "<VALUE>"` or use [WSLENV](https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/)
 
 ## Known Issues

--- a/WslInterop.psm1
+++ b/WslInterop.psm1
@@ -88,9 +88,10 @@ function global:Import-WslCommand() {
 
         # Build the command to pass to WSL.
         `$distribution = ("-d `$(`$WslDefaultParameterValues."-d")", "")[`$WslDefaultParameterValues."-d" -eq `$null]
+        `$username = ("-u `$(`$WslDefaultParameterValues."-u")", "")[`$WslDefaultParameterValues."-u" -eq `$null]
         `$environmentVariables = ((`$WslEnvironmentVariables.Keys | ForEach-Object { "`$_='`$(`$WslEnvironmentVariables."`$_")'" }), "")[`$WslEnvironmentVariables.Count -eq 0]
         `$defaultArgs = (`$WslDefaultParameterValues."$_", "")[`$WslDefaultParameterValues.Disabled -eq `$true]
-        `$commandLine = "`$distribution `$environmentVariables $_ `$defaultArgs `$args" -split ' '
+        `$commandLine = "`$distribution `$username `$environmentVariables $_ `$defaultArgs `$args" -split ' '
 
         # Invoke the command.
         if (`$input.MoveNext()) {


### PR DESCRIPTION
I run WSL as a non-root user. This PR adds support for setting `$WslDefaultParameterValues["-u"] = "<username>"` in `$PROFILE` to run WSL commands as the given user instead of root.