### PR TITLE
fix #29 piping

### DIFF
--- a/WslInterop.psm1
+++ b/WslInterop.psm1
@@ -115,7 +115,7 @@ function global:Import-WslCommand() {
             `$input.Reset()
             `$inputFile = "/tmp/wslPipe.`$(New-Guid)"
             `$input | Out-String -Stream | wsl -e bash -c "cat > `$inputFile"
-            wsl.exe -e bash -c "cat `$inputFile | $_ `$(`$args -split ' ') && rm `$inputFile"
+            wsl.exe -e bash -c "cat `$inputFile | $_ `$commandLine && rm `$inputFile"
         } else {
             wsl.exe `$commandLine
         }
@@ -135,7 +135,8 @@ function global:Import-WslCommand() {
         if ($null -eq $global:WslCompletionFunctions) {
             if (Test-Path $WslCompletionFunctionsCache) {
                 $global:WslCompletionFunctions = Import-Clixml $WslCompletionFunctionsCache
-            } else {
+            }
+            else {
                 $global:WslCompletionFunctions = @{}
             }
         }
@@ -152,8 +153,9 @@ function global:Import-WslCommand() {
                 # If the default completion function was overridden, use that.
                 if ($global:WslCompletionFunctions["-D"] -ne "_completion_loader") {
                     $global:WslCompletionFunctions[$command] = $global:WslCompletionFunctions["-D"]
-                # Otherwise, resort to _minimal which will return Linux file paths.
-                } else {
+                    # Otherwise, resort to _minimal which will return Linux file paths.
+                }
+                else {
                     $global:WslCompletionFunctions[$command] = "_minimal"
                 }
             }
@@ -176,17 +178,20 @@ function global:Import-WslCommand() {
                 $previousWord = $commandAst.CommandElements[$i - 1].Extent.Text
                 $COMP_CWORD = $i
                 break
-            } elseif ($cursorPosition -eq $extent.EndColumnNumber) {
+            }
+            elseif ($cursorPosition -eq $extent.EndColumnNumber) {
                 # The cursor is immediately after the current word.
                 $previousWord = $extent.Text
                 $COMP_CWORD = $i + 1
                 break
-            } elseif ($cursorPosition -lt $extent.StartColumnNumber) {
+            }
+            elseif ($cursorPosition -lt $extent.StartColumnNumber) {
                 # The cursor is within whitespace between the previous and current words.
                 $previousWord = $commandAst.CommandElements[$i - 1].Extent.Text
                 $COMP_CWORD = $i
                 break
-            } elseif ($i -eq $commandAst.CommandElements.Count - 1 -and $cursorPosition -gt $extent.EndColumnNumber) {
+            }
+            elseif ($i -eq $commandAst.CommandElements.Count - 1 -and $cursorPosition -gt $extent.EndColumnNumber) {
                 # The cursor is within whitespace at the end of the line.
                 $previousWord = $extent.Text
                 $COMP_CWORD = $i + 1
@@ -232,7 +237,8 @@ function global:Import-WslCommand() {
             if ($wordToComplete -match "(.*=).*") {
                 $completionText = Format-WslArgument ($Matches[1] + $_) $true
                 $listItemText = $_
-            } else {
+            }
+            else {
                 $completionText = Format-WslArgument $_ $true
                 $listItemText = $completionText
             }
@@ -270,7 +276,8 @@ function global:Format-WslArgument([string]$arg, [bool]$interactive) {
     
     if ($interactive) {
         $arg = (($arg -replace '([ ,(){}|&;])', '`$1'), "'$arg'")[$arg.Contains(" ")]
-    } else {
+    }
+    else {
         $arg = $arg -replace '(\\\\|\\[ ,(){}|&;])', '\\$1'
 
         while ($arg -match '([^\\](\\\\)*)([ ,(){}|&;])') {

--- a/WslInterop.psm1
+++ b/WslInterop.psm1
@@ -113,7 +113,9 @@ function global:Import-WslCommand() {
         # Invoke the command.
         if (`$input.MoveNext()) {
             `$input.Reset()
-            `$input | wsl.exe `$commandLine
+            `$inputFile = "/tmp/wslPipe.`$(New-Guid)"
+            `$input | Out-String -Stream | wsl -e bash -c "cat > `$inputFile"
+            wsl.exe -e bash -c "cat `$inputFile | $_ `$(`$args -split ' ') && rm `$inputFile"
         } else {
             wsl.exe `$commandLine
         }


### PR DESCRIPTION
fix #29 

When piping to a command, the pipe "contents" will be stored in a file `/tmp/wslPipe.<random-guid>` and then pipied to the command inside wsl. This allows interactive commands to work while piping.

Known issue:
- under some circumstances, the piping contents wont be encoded right. This is mainly an issue when the pipe contents contain special characters like emojis